### PR TITLE
Fix ugly button rendering on safari

### DIFF
--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -19,7 +19,9 @@
 					lovers.
 				</p>
 				{#if $currentUser}
-					<a type="button" class="btn btn-primary" href={`${base}/challenges`}>Challenges</a>
+					<button type="button" class="btn btn-primary" href={`${base}/challenges`}
+						>Challenges</button
+					>
 				{:else}
 					<button
 						type="button"

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -11,7 +11,7 @@
 $enable-rounded: false;
 $font-family-base: 'Computer Modern';
 
-$primary: #212120;
+$primary: #202020;
 $secondary: #a8a8a8;
 $success: #0a0;
 $danger: #a00;
@@ -27,6 +27,12 @@ $container-max-widths: (
 	xl: 768px,
 	xxl: 960px
 );
+
+/** ====================
+= Button Customizations
+======================== **/
+
+$btn-border-radius: 0px;
 
 @import 'bootstrap/scss/bootstrap';
 @import 'bootstrap/scss/functions';


### PR DESCRIPTION
1. Also makes the primary color #202020 (color used in designs), instead of #212121.
2. Forces all buttons to not have rounded corners.
3. Makes button render correctly on Safari.