### PR TITLE
Add hashtag for sign-in/up, add correct first modal dep. on button

### DIFF
--- a/src/lib/components/Quote.svelte
+++ b/src/lib/components/Quote.svelte
@@ -2,8 +2,8 @@
 	export let author: string;
 </script>
 
-<div class="d-inline-block clearfix px-2">
-	<h3 class="d-inline-block fw-bold p-0 m-0"><slot /></h3>
+<div class="d-inline-block clearfix">
+	<h3 class="d-inline-block fw-bold p-0 m-0 quote-quote"><slot /></h3>
 	<br />
-	<p class="d-inline-block p-0 m-0 text-black-50 fst-italic float-end">- {author}</p>
+	<p class="d-inline-block p-0 m-0 text-black-50 fst-italic float-end quote-author">- {author}</p>
 </div>

--- a/src/lib/components/SignIn.svelte
+++ b/src/lib/components/SignIn.svelte
@@ -2,25 +2,26 @@
 	import Quote from './Quote.svelte';
 </script>
 
-<div>
+<div class="col-12">
 	<Quote author="Victor Hugo">He who opens a school door, closes a prison.</Quote>
 </div>
-
-<div class="row px-2 py-4">
-	<div class="col-md-8">
-		<img
-			class="sign-in-image"
-			src="https://github.com/quantu-app/design-platform/raw/master/app/resources/sign_up_and_login/1x/Door-Opening.png"
-			alt="opening a door"
-		/>
-	</div>
-	<div class="col-md-4">
-		<slot />
+<div class="col-12 py-4">
+	<div class="row">
+		<div class="col-md-7">
+			<img
+				class="sign-in-image"
+				src="https://github.com/quantu-app/design-platform/raw/master/app/resources/sign_up_and_login/1x/Door-Opening.png"
+				alt="opening a door"
+			/>
+		</div>
+		<div class="col-md-5">
+			<slot />
+		</div>
 	</div>
 </div>
 
 <style>
 	.sign-in-image {
-		border: 1px solid #777;
+		border: 1px solid #707070;
 	}
 </style>

--- a/src/lib/components/SignInUpModal.svelte
+++ b/src/lib/components/SignInUpModal.svelte
@@ -15,15 +15,7 @@
 
 	let loading = false;
 	let SignInUpComponent = SignIn;
-
-	function setInitialSignInUpComponent(event) {
-		const btn = event.relatedTarget;
-		if (btn.dataset.signup) {
-			SignInUpComponent = SignUp;
-		} else {
-			SignInUpComponent = SignIn;
-		}
-	}
+	let modalElement: HTMLDivElement;
 
 	function signInWith(provider = 'google') {
 		loading = true;
@@ -56,55 +48,33 @@
 		}, 1000);
 	}
 
-	function toggleSignInUp() {
-		console.log('toggle');
-		if (SignInUpComponent === SignIn) {
+	const toggleSignInUp = () => {
+		SignInUpComponent = SignInUpComponent === SignIn ? SignUp : SignIn;
+	};
+
+	function setSignInUpComponentFromTriggerElement(event) {
+		const btn = event.relatedTarget;
+		console.log(btn);
+		if (btn.dataset.signup) {
 			SignInUpComponent = SignUp;
-			console.log('sign-up');
-			window.location.hash = '#sign-up';
 		} else {
 			SignInUpComponent = SignIn;
-			window.location.hash = '#sign-in';
-		}
-
-		return false;
-	}
-
-	function resetHashTag() {
-		if (browser && window.location.hash) {
-			window.location.hash = '';
 		}
 	}
 
 	onMount(() => {
-		document.addEventListener('show.bs.modal', setInitialSignInUpComponent, false);
-		document.addEventListener('show.bs.modal', toggleSignInUp, false);
-		document.addEventListener('hidden.bs.modal', resetHashTag, false);
+		modalElement.addEventListener('show.bs.modal', setSignInUpComponentFromTriggerElement, false);
 	});
 
 	onDestroy(() => {
 		if (browser) {
-			document.removeEventListener('show.bs.modal', setInitialSignInUpComponent, false);
-			document.removeEventListener('show.bs.modal', toggleSignInUp, false);
-			document.addEventListener('hidden.bs.modal', resetHashTag, false);
+			modalElement.removeEventListener(
+				'show.bs.modal',
+				setSignInUpComponentFromTriggerElement,
+				false
+			);
 		}
 	});
-
-	if (browser && window.location.hash) {
-		let hashSignInUpHash = false;
-		if (window.location.hash == '#sign-up') {
-			SignInUpComponent = SignUp;
-			hashSignInUpHash = true;
-		}
-		if (window.location.hash == '#sign-in') {
-			SignInUpComponent = SignIn;
-			hashSignInUpHash = true;
-		}
-
-		if (hashSignInUpHash) {
-			jQuery('#sign-in-up-modal').modal('show');
-		}
-	}
 </script>
 
 <div
@@ -114,58 +84,73 @@
 	aria-labelledby="sign-in-up-modal-label"
 	aria-hidden="true"
 	role="dialog"
+	bind:this={modalElement}
 >
-	<div class="modal-dialog modal-lg" role="document">
+	<div class="modal-dialog modal-fullscreen" role="document">
 		<div class="modal-content">
 			<div class="modal-header">
 				<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" />
 			</div>
 			<div class="modal-body">
-				<svelte:component this={SignInUpComponent}>
-					<button
-						type="button"
-						disabled={loading}
-						on:click={() => signInWith('google')}
-						class="btn btn-primary google w-100 oauth mt-0">Google</button
-					>
-					<button
-						type="button"
-						disabled={loading}
-						on:click={() => signInWith('facebook')}
-						class="btn btn-primary facebook w-100 oauth">Facebook</button
-					>
-				</svelte:component>
-				<div class="text-center">
-					{#if SignInUpComponent === SignUp}
-						<p>
-							Already have an account? <a
-								href="#sign-in"
-								class="link-primary"
-								on:click={toggleSignInUp}>Sign in</a
+				<div class="container">
+					<div class="row mb-4 p-4 wrapper">
+						<svelte:component this={SignInUpComponent}>
+							<button
+								type="button"
+								disabled={loading}
+								on:click={() => signInWith('google')}
+								class="btn btn-primary google w-100 oauth mb-4 mt-md-0 mt-4">Google</button
 							>
-						</p>
-					{:else}
-						<p>
-							New around here? <a href="#sign-up" class="link-primary" on:click={toggleSignInUp}
-								>Sign up</a
+							<button
+								type="button"
+								disabled={loading}
+								on:click={() => signInWith('facebook')}
+								class="btn btn-primary facebook w-100 oauth">Facebook</button
 							>
-						</p>
-					{/if}
+						</svelte:component>
+					</div>
+					<div class="row">
+						<div class="text-center">
+							{#if SignInUpComponent === SignUp}
+								<p>
+									Already have an account? <a
+										class="link-primary sign-in-up"
+										on:click={toggleSignInUp}>Sign in</a
+									>
+								</p>
+							{:else}
+								<p>
+									New around here? <a class="link-primary sign-in-up" on:click={toggleSignInUp}
+										>Sign up</a
+									>
+								</p>
+							{/if}
+						</div>
+					</div>
 				</div>
-			</div>
-			<div class="modal-footer">
-				<button type="button" class="btn btn-secondary text-white" data-bs-dismiss="modal"
-					>Close</button
-				>
 			</div>
 		</div>
 	</div>
 </div>
 
 <style lang="scss">
-	.oauth {
-		margin-top: 1rem;
+	#sign-in-up-modal {
+		.wrapper {
+			border: 1px solid #ccc;
+		}
+		.modal-header {
+			border-bottom: none;
+		}
+		.btn-close {
+			margin-left: 0;
+			outline: none;
+			box-shadow: none;
+		}
+		.sign-in-up {
+			cursor: pointer;
+		}
 	}
+
 	.google {
 		font-family: Roboto, arial, sans-serif;
 		font-weight: bold;

--- a/src/lib/components/SignInUpModal.svelte
+++ b/src/lib/components/SignInUpModal.svelte
@@ -10,8 +10,20 @@
 	import SignIn from './SignIn.svelte';
 	import SignUp from './SignUp.svelte';
 	import { signInWithToken } from '$lib/state/user';
+	import { onDestroy, onMount } from 'svelte';
+	import { browser } from '$app/env';
 
 	let loading = false;
+	let SignInUpComponent = SignIn;
+
+	function setInitialSignInUpComponent(event) {
+		const btn = event.relatedTarget;
+		if (btn.dataset.signup) {
+			SignInUpComponent = SignUp;
+		} else {
+			SignInUpComponent = SignIn;
+		}
+	}
 
 	function signInWith(provider = 'google') {
 		loading = true;
@@ -44,12 +56,53 @@
 		}, 1000);
 	}
 
-	let SignInUpComponent = SignIn;
 	function toggleSignInUp() {
+		console.log('toggle');
 		if (SignInUpComponent === SignIn) {
 			SignInUpComponent = SignUp;
+			console.log('sign-up');
+			window.location.hash = '#sign-up';
 		} else {
 			SignInUpComponent = SignIn;
+			window.location.hash = '#sign-in';
+		}
+
+		return false;
+	}
+
+	function resetHashTag() {
+		if (browser && window.location.hash) {
+			window.location.hash = '';
+		}
+	}
+
+	onMount(() => {
+		document.addEventListener('show.bs.modal', setInitialSignInUpComponent, false);
+		document.addEventListener('show.bs.modal', toggleSignInUp, false);
+		document.addEventListener('hidden.bs.modal', resetHashTag, false);
+	});
+
+	onDestroy(() => {
+		if (browser) {
+			document.removeEventListener('show.bs.modal', setInitialSignInUpComponent, false);
+			document.removeEventListener('show.bs.modal', toggleSignInUp, false);
+			document.addEventListener('hidden.bs.modal', resetHashTag, false);
+		}
+	});
+
+	if (browser && window.location.hash) {
+		let hashSignInUpHash = false;
+		if (window.location.hash == '#sign-up') {
+			SignInUpComponent = SignUp;
+			hashSignInUpHash = true;
+		}
+		if (window.location.hash == '#sign-in') {
+			SignInUpComponent = SignIn;
+			hashSignInUpHash = true;
+		}
+
+		if (hashSignInUpHash) {
+			jQuery('#sign-in-up-modal').modal('show');
 		}
 	}
 </script>
@@ -60,8 +113,9 @@
 	tabindex="-1"
 	aria-labelledby="sign-in-up-modal-label"
 	aria-hidden="true"
+	role="dialog"
 >
-	<div class="modal-dialog modal-lg">
+	<div class="modal-dialog modal-lg" role="document">
 		<div class="modal-content">
 			<div class="modal-header">
 				<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" />
@@ -84,13 +138,16 @@
 				<div class="text-center">
 					{#if SignInUpComponent === SignUp}
 						<p>
-							Already have an account? <a href="#" class="link-primary" on:click={toggleSignInUp}
-								>Sign in</a
+							Already have an account? <a
+								href="#sign-in"
+								class="link-primary"
+								on:click={toggleSignInUp}>Sign in</a
 							>
 						</p>
 					{:else}
 						<p>
-							New around here? <a href="#" class="link-primary" on:click={toggleSignInUp}>Sign up</a
+							New around here? <a href="#sign-up" class="link-primary" on:click={toggleSignInUp}
+								>Sign up</a
 							>
 						</p>
 					{/if}

--- a/src/lib/components/SignInUpModal.svelte
+++ b/src/lib/components/SignInUpModal.svelte
@@ -54,7 +54,7 @@
 
 	function setSignInUpComponentFromTriggerElement(event) {
 		const btn = event.relatedTarget;
-		console.log(btn);
+
 		if (btn.dataset.signup) {
 			SignInUpComponent = SignUp;
 		} else {
@@ -136,7 +136,7 @@
 <style lang="scss">
 	#sign-in-up-modal {
 		.wrapper {
-			border: 1px solid #ccc;
+			border: 1px solid #707070;
 		}
 		.modal-header {
 			border-bottom: none;

--- a/src/lib/components/SignUp.svelte
+++ b/src/lib/components/SignUp.svelte
@@ -4,28 +4,30 @@
 	import Quote from './Quote.svelte';
 </script>
 
-<div>
+<div class="col-12">
 	<Quote author="Lao Tzu">The journey of a thousand miles begins with a single step.</Quote>
 </div>
 
-<div class="row px-2 py-4">
-	<div class="col-md-8">
-		<img
-			class="sign-in-image"
-			src="https://github.com/quantu-app/design-platform/raw/master/app/resources/sign_up_and_login/1x/Journey-Man.png"
-			alt="Taking the first step"
-		/>
-	</div>
-	<div class="col-md-4">
-		<slot />
-		<div class="mt-4">
-			<p>
-				By joining, you are agreeing to our <a target="_blank" href={`${base}/info/terms-of-use`}
-					>Terms</a
-				>
-				and
-				<a target="_blank" href={`${base}/info/privacy-policy`}>Privacy Policy</a>
-			</p>
+<div class="col-12 py-4">
+	<div class="row">
+		<div class="col-md-7">
+			<img
+				class="sign-in-image"
+				src="https://github.com/quantu-app/design-platform/raw/master/app/resources/sign_up_and_login/1x/Journey-Man.png"
+				alt="Taking the first step"
+			/>
+		</div>
+		<div class="col-md-5">
+			<slot />
+			<div class="mt-4">
+				<p>
+					By joining, you are agreeing to our <a target="_blank" href={`${base}/info/terms-of-use`}
+						>Terms</a
+					>
+					and
+					<a target="_blank" href={`${base}/info/privacy-policy`}>Privacy Policy</a>
+				</p>
+			</div>
 		</div>
 	</div>
 </div>

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -27,6 +27,7 @@
 						type="button"
 						data-bs-toggle="modal"
 						data-bs-target="#sign-in-up-modal"
+						data-signup="true"
 						class="btn btn-primary"
 					>
 						Get Started


### PR DESCRIPTION
1. Given #sign-up => open sign-up modal
2. Given #sign-in in url => open sign-in modal
3. If clicking on a button with attribute `data-signup` open the sign-up modal.

There is also a wierd bug I am trying to fix here (still not fixed) where sometimes the content of the modal does not render (tested in brave).

Also using the jq/bootstrap modal here, seems very hacky, since I have to use the dom event api to hook into it and adjust things, not sure exactly how we want to do modals overall, although this hacky approach seems to be working for now.